### PR TITLE
Loggy enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "6",
     "react-scripts": "5.0.1",
     "typescript": "^4.7.4",
+    "url-safe-base64": "^1.2.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Log, parseLog } from "./logs/parseLog";
 import { LogViewer } from "./viewer/LogViewer";
 import { Buffer } from "buffer";
+import { decode } from "url-safe-base64";
 import "./App.css";
 
 function useFileUpload(): [JSX.Element, ArrayBuffer | undefined] {
@@ -58,7 +59,7 @@ function App() {
   useEffect(() => {
     async function getLog() {
       if (logURL !== null) {
-        const url = Buffer.from(logURL, "base64").toString();
+        const url = Buffer.from(decode(logURL), "base64").toString();
         const req = await fetch(url, { mode: "cors" });
         const log = await req.arrayBuffer();
         setUrlBuf(log);

--- a/src/logs/parseLog.ts
+++ b/src/logs/parseLog.ts
@@ -72,7 +72,9 @@ export async function parseLog(data: ArrayBuffer): Promise<Log> {
   }
 
   return {
-    xlLog: await getLogFile<XLTroubleshooting>(zip, "output.log", xlRegex),
+    xlLog: zip.file("output.log") !== null
+      ? await getLogFile<XLTroubleshooting>(zip, "output.log", xlRegex)
+      : await getLogFile<XLTroubleshooting>(zip, "launcher.log", xlRegex),
     dalamudLog: await getLogFile<DalamudTroubleshooting>(
       zip,
       "dalamud.log",

--- a/src/logs/troubleshooting.ts
+++ b/src/logs/troubleshooting.ts
@@ -79,7 +79,8 @@ export enum IndexIntegrity {
 export enum Platform {
   Windows = 0,
   WindowsOnLinux = 1,
-  Linux = 2
+  Linux = 2,
+  MacOS = 3
 }
 
 export enum DalamudLoadMethod {

--- a/src/viewer/LogViewer.tsx
+++ b/src/viewer/LogViewer.tsx
@@ -34,6 +34,16 @@ export function LogViewer(props: LogViewerProps) {
         </>
       );
       break;
+    case "launcher.log":
+      el = (
+        <>
+          <XLLogViewer log={log.xlLog!} />
+          <h2 className="text-xl">Log</h2>
+          <hr />
+          <RawLog log={log.xlLog!.data} />
+        </>
+      );
+      break;
     default:
       if (selectedLog == null) {
         el = <p>Select a log to start!</p>;

--- a/src/viewer/XLLogViewer.tsx
+++ b/src/viewer/XLLogViewer.tsx
@@ -82,10 +82,6 @@ export function XLLogViewer(props: XLLogViewerProps) {
             Encrypted arguments:{" "}
             {troubleshooting.EncryptArguments ? "true" : "false"}
           </li>
-          <li>
-            Steam integration:{" "}
-            {troubleshooting.SteamIntegration ? "true" : "false"}
-          </li>
           <li>UID cache: {troubleshooting.IsUidCache ? "true" : "false"}</li>
           <li>
             Dalamud enabled: {troubleshooting.DalamudEnabled ? "true" : "false"}


### PR DESCRIPTION
- remove SteamIntegration - XIVLauncher doesn't use this anymore and it's always set to null/false.
- use url-safe base64 decoding (Normal base64 can include `/`, `+`, and `=` which would break otherwise. (Franzbot is already using url-safe base64 encode)
- handle xlcore's launcher.log files. *Will need XIVLauncher to update platform code for platform reporting to work correctly.